### PR TITLE
사용자 핸들링 기능

### DIFF
--- a/api-user/src/main/java/com/user/config/CurrentUserArgumentResolver.java
+++ b/api-user/src/main/java/com/user/config/CurrentUserArgumentResolver.java
@@ -22,17 +22,13 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
-        CurrentUser currentUserAnnotation = parameter.getParameterAnnotation(CurrentUser.class);
-        boolean required = currentUserAnnotation.required();
-
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        boolean isAuthenticated = isAuthenticatedUser(authentication);
 
-        if (required && !isAuthenticated) {
+        if (parameter.getParameterAnnotation(CurrentUser.class).required() && !isAuthenticatedUser(authentication)) {
             throw new CommonException(LOGIN_REQUIRED);
         }
 
-        return isAuthenticated ? ((UserPrincipal) authentication.getPrincipal()).getUser() : null;
+        return isAuthenticatedUser(authentication) ? ((UserPrincipal) authentication.getPrincipal()).getUser() : null;
     }
 
     private boolean isAuthenticatedUser(Authentication authentication) {

--- a/api-user/src/main/java/com/user/config/CurrentUserArgumentResolver.java
+++ b/api-user/src/main/java/com/user/config/CurrentUserArgumentResolver.java
@@ -1,0 +1,43 @@
+package com.user.config;
+
+import com.user.config.security.CurrentUser;
+import com.user.config.security.UserPrincipal;
+import com.user.utils.error.CommonException;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static com.user.enums.ErrorType.LOGIN_REQUIRED;
+
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        CurrentUser currentUserAnnotation = parameter.getParameterAnnotation(CurrentUser.class);
+        boolean required = currentUserAnnotation.required();
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        boolean isAuthenticated = isAuthenticatedUser(authentication);
+
+        if (required && !isAuthenticated) {
+            throw new CommonException(LOGIN_REQUIRED);
+        }
+
+        return isAuthenticated ? ((UserPrincipal) authentication.getPrincipal()).getUser() : null;
+    }
+
+    private boolean isAuthenticatedUser(Authentication authentication) {
+        return authentication != null
+                && authentication.isAuthenticated()
+                && authentication.getPrincipal() instanceof UserPrincipal;
+    }
+}

--- a/api-user/src/main/java/com/user/config/WebConfig.java
+++ b/api-user/src/main/java/com/user/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.user.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new CurrentUserArgumentResolver());
+    }
+}

--- a/api-user/src/main/java/com/user/config/WebConfig.java
+++ b/api-user/src/main/java/com/user/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.user.config;
 
+import com.user.config.security.CurrentUserArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;

--- a/api-user/src/main/java/com/user/config/security/CurrentUser.java
+++ b/api-user/src/main/java/com/user/config/security/CurrentUser.java
@@ -1,7 +1,5 @@
 package com.user.config.security;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -9,6 +7,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
-@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : user")
 public @interface CurrentUser {
+
+    boolean required() default true;
 }

--- a/api-user/src/main/java/com/user/config/security/CurrentUserArgumentResolver.java
+++ b/api-user/src/main/java/com/user/config/security/CurrentUserArgumentResolver.java
@@ -21,12 +21,13 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        boolean isAuthenticatedUser = isAuthenticatedUser(authentication);
 
-        if (parameter.getParameterAnnotation(CurrentUser.class).required() && !isAuthenticatedUser(authentication)) {
+        if (parameter.getParameterAnnotation(CurrentUser.class).required() && !isAuthenticatedUser) {
             throw new CommonException(LOGIN_REQUIRED);
         }
 
-        return isAuthenticatedUser(authentication) ? ((UserPrincipal) authentication.getPrincipal()).getUser() : null;
+        return isAuthenticatedUser ? ((UserPrincipal) authentication.getPrincipal()).getUser() : null;
     }
 
     private boolean isAuthenticatedUser(Authentication authentication) {

--- a/api-user/src/main/java/com/user/config/security/CurrentUserArgumentResolver.java
+++ b/api-user/src/main/java/com/user/config/security/CurrentUserArgumentResolver.java
@@ -1,7 +1,5 @@
-package com.user.config;
+package com.user.config.security;
 
-import com.user.config.security.CurrentUser;
-import com.user.config.security.UserPrincipal;
 import com.user.utils.error.CommonException;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;

--- a/api-user/src/main/java/com/user/enums/ErrorType.java
+++ b/api-user/src/main/java/com/user/enums/ErrorType.java
@@ -24,7 +24,8 @@ public enum ErrorType {
     UNAUTHORIZED_TOKEN(UNAUTHORIZED, "Unauthorized token", INFO),
     LOGIN_FAIL(UNAUTHORIZED, "Invalid email or password", INFO),
     USER_NOT_FOUND(NOT_FOUND, "User not found", INFO),
-    ACCESS_DENIED(FORBIDDEN, "Access denied", INFO);
+    ACCESS_DENIED(FORBIDDEN, "Access denied", INFO),
+    LOGIN_REQUIRED(UNAUTHORIZED, "Login required", INFO);
 
     private final HttpStatus status;
     private final String message;

--- a/api-user/src/unitTest/java/com/user/config/security/CurrentUserArgumentResolverTest.java
+++ b/api-user/src/unitTest/java/com/user/config/security/CurrentUserArgumentResolverTest.java
@@ -1,0 +1,141 @@
+package com.user.config.security;
+
+import com.storage.entity.User;
+import com.user.utils.error.CommonException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static com.user.enums.ErrorType.LOGIN_REQUIRED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@WebMvcTest(CurrentUserArgumentResolver.class)
+class CurrentUserArgumentResolverTest {
+
+    @Mock
+    private MethodParameter parameter;
+    @Mock
+    private ModelAndViewContainer mavContainer;
+    @Mock
+    private NativeWebRequest webRequest;
+
+    @InjectMocks
+    private CurrentUserArgumentResolver resolver;
+
+    @Test
+    @DisplayName("CurrentUser 어노테이션이 존재하면 파라미터를 지원한다")
+    void supportsParameterWhenCurrenUserAnnotationExists() {
+        given(parameter.hasParameterAnnotation(CurrentUser.class)).willReturn(true);
+        assertThat(resolver.supportsParameter(parameter)).isTrue();
+    }
+
+    @Test
+    @DisplayName("CurrentUser 어노테이션이 존재하지 않으면 파라미터를 지원하지 않는다.")
+    void supportsParameterWhenCurrenUserAnnotationNotExists() {
+        given(parameter.hasParameterAnnotation(CurrentUser.class)).willReturn(false);
+        assertThat(resolver.supportsParameter(parameter)).isFalse();
+    }
+
+    @Test
+    @WithMockUserPrincipal
+    @DisplayName("CurrentUser required(true)일때 인증된 사용자가 존재하면 사용자를 반환한다.")
+    void authenticatedUserAndAnnotationCurrenUserExists() {
+        // given
+        CurrentUser currentUser = mock(CurrentUser.class);
+        given(parameter.getParameterAnnotation(CurrentUser.class)).willReturn(currentUser);
+        given(currentUser.required()).willReturn(true);
+
+        // when
+        Object result = resolver.resolveArgument(parameter, mavContainer, webRequest, null);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(User.class);
+    }
+
+    @Test
+    @WithAnonymousUser
+    @DisplayName("CurrentUser required(true)일때 Anonymous 사용자 이면 예외가 발생된다.")
+    void anonymousUserAndAnnotationCurrenUserExists() {
+        // given
+        CurrentUser currentUser = mock(CurrentUser.class);
+        given(parameter.getParameterAnnotation(CurrentUser.class)).willReturn(currentUser);
+        given(currentUser.required()).willReturn(true);
+
+        // when && then
+        assertThatThrownBy(() -> resolver.resolveArgument(parameter, mavContainer, webRequest, null))
+                .isInstanceOf(CommonException.class)
+                .hasMessage(LOGIN_REQUIRED.getMessage());
+    }
+
+    @Test
+    @DisplayName("CurrentUser required(true)일때 인증된 사용자가 존재하지 않으면 예외를 발생시킨다.")
+    void notAuthenticatedUserAndAnnotationCurrenUserExists() {
+        // given
+        CurrentUser currentUser = mock(CurrentUser.class);
+        given(parameter.getParameterAnnotation(CurrentUser.class)).willReturn(currentUser);
+        given(currentUser.required()).willReturn(true);
+
+        // when && then
+        assertThatThrownBy(() -> resolver.resolveArgument(parameter, mavContainer, webRequest, null))
+                .isInstanceOf(CommonException.class)
+                .hasMessage(LOGIN_REQUIRED.getMessage());
+    }
+
+    @Test
+    @WithAnonymousUser
+    @DisplayName("CurrentUser required(false)일때 Anonymous 사용자 이면 null을 반환한다.")
+    void anonymousUserAndAnnotationCurrenUserNotExists() {
+        // given
+        CurrentUser currentUser = mock(CurrentUser.class);
+        given(parameter.getParameterAnnotation(CurrentUser.class)).willReturn(currentUser);
+        given(currentUser.required()).willReturn(false);
+
+        // when
+        Object result = resolver.resolveArgument(parameter, mavContainer, webRequest, null);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @WithMockUserPrincipal
+    @DisplayName("CurrentUser required(false)일때 인증된 사용자가 존재하면 사용자를 반환한다.")
+    void authenticatedUserAndAnnotationCurrenUserNotExists() {
+        // given
+        CurrentUser currentUser = mock(CurrentUser.class);
+        given(parameter.getParameterAnnotation(CurrentUser.class)).willReturn(currentUser);
+        given(currentUser.required()).willReturn(false);
+
+        // when
+        Object result = resolver.resolveArgument(parameter, mavContainer, webRequest, null);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(User.class);
+    }
+
+    @Test
+    @DisplayName("CurrentUser required(false)일때 인증된 사용자가 존재하지 않으면 null을 반환한다.")
+    void notAuthenticatedUserAndAnnotationCurrenUserNotExists() {
+        // given
+        CurrentUser currentUser = mock(CurrentUser.class);
+        given(parameter.getParameterAnnotation(CurrentUser.class)).willReturn(currentUser);
+        given(currentUser.required()).willReturn(false);
+
+        // when
+        Object result = resolver.resolveArgument(parameter, mavContainer, webRequest, null);
+
+        // then
+        assertThat(result).isNull();
+    }
+}

--- a/api-user/src/unitTest/java/com/user/config/security/WithMockUserPrincipal.java
+++ b/api-user/src/unitTest/java/com/user/config/security/WithMockUserPrincipal.java
@@ -1,0 +1,11 @@
+package com.user.config.security;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockUserPrincipalSecurityContextFactory.class)
+public @interface WithMockUserPrincipal {
+}

--- a/api-user/src/unitTest/java/com/user/config/security/WithMockUserPrincipalSecurityContextFactory.java
+++ b/api-user/src/unitTest/java/com/user/config/security/WithMockUserPrincipalSecurityContextFactory.java
@@ -1,0 +1,26 @@
+package com.user.config.security;
+
+import com.storage.entity.User;
+import com.user.support.fixture.entity.AccountFixtureFactory;
+import com.user.support.fixture.entity.UserFixtureFactory;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockUserPrincipalSecurityContextFactory implements WithSecurityContextFactory<WithMockUserPrincipal> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockUserPrincipal customUser) {
+
+        User user = UserFixtureFactory.create(AccountFixtureFactory.create());
+        UserPrincipal principal = UserPrincipal.of(user);
+        Authentication authentication = UsernamePasswordAuthenticationToken.authenticated(
+                principal, principal.getPassword(), principal.getAuthorities()
+        );
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(authentication);
+        return context;
+    }
+}


### PR DESCRIPTION
## **[Title]**

- #31 

## **[Context]**

- 추후에 추가되는 게시물 읽기 기능에서 프리미엄 사용자만 읽기 기능을 위해 resolver를 추가하였습니다. 
- 이 기능을 통해 꼭 로그인이 필요하지 않은 api에서 user가 로그인 한 경우, 로그인 하지 않은 경우에 따라 핸들링할 수 있습니다. 

## **[Studied for PR]**

### HandlerMethodArgumentResolver
컨트롤러 메서드의 파라미터를 해석하여 필요한 데이터를 제공하는 인터페이스입니다.   
`@RequestParam`, `@PathVariable`, `@RequestBody` 등의 어노테이션을 사용하는 방식처럼 요청을 메서드 파라미터로 바인딩 할 수 있습니다.   
구현하여 사용할 때는 특정 조건에 맞는 파라미터가 있을 때, 파라미터를 처리합니다. (현재는 `@CurrentUser`)  


### WebMvcConfigurer 
Spring MVC의 동작을 커스텀 할 수 있는 메서드를 제공합니다.  
대표적인 메서드는 다음과 같습니다.   
- addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) 
- addCorsMappings(CorsRegistry registry)
- addInterceptors(InterceptorRegistry registry)
- addFormatters(FormatterRegistry registry) 

위 메서드 들을 통해 커스텀 CORS, resolver, interceptor, formatter 등을 등록하여 확장할 수 있습니다. 

## **Checklist**

- [X] base, compare branch가 적절하게 선택되었나요?
- [X] 로컬 환경에서 충분히 테스트 하셨나요?
